### PR TITLE
Add missing lego object factory types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ISLE.EXE
 LEGO1.DLL
 build/
 *.swp
+
+# IDE artifacts
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(lego1 SHARED
   LEGO1/jukeboxentity.cpp
   LEGO1/jukeboxstate.cpp
   LEGO1/lego3dwavepresenter.cpp
+  LEGO1/legoact2.cpp
   LEGO1/legoact2state.cpp
   LEGO1/legoactioncontrolpresenter.cpp
   LEGO1/legoactor.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(lego1 SHARED
   LEGO1/jukebox.cpp
   LEGO1/jukeboxentity.cpp
   LEGO1/jukeboxstate.cpp
+  LEGO1/lego3dwavepresenter.cpp
   LEGO1/legoact2state.cpp
   LEGO1/legoactioncontrolpresenter.cpp
   LEGO1/legoactor.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(lego1 SHARED
   LEGO1/legophonemepresenter.cpp
   LEGO1/legoplantmanager.cpp
   LEGO1/legorace.cpp
+  LEGO1/legoracecar.cpp
   LEGO1/legoroi.cpp
   LEGO1/legosoundmanager.cpp
   LEGO1/legostate.cpp

--- a/LEGO1/lego3dwavepresenter.cpp
+++ b/LEGO1/lego3dwavepresenter.cpp
@@ -1,0 +1,6 @@
+#include "lego3dwavepresenter.h"
+
+#include "decomp.h"
+
+// Uncomment when member class variables are fleshed out.
+// DECOMP_SIZE_ASSERT(Lego3DWavePresenter, 0xa0);

--- a/LEGO1/lego3dwavepresenter.h
+++ b/LEGO1/lego3dwavepresenter.h
@@ -1,13 +1,19 @@
 #ifndef LEGO3DWAVEPRESENTER_H
 #define LEGO3DWAVEPRESENTER_H
 
-#include "legowavepresenter.h"
+#include "mxwavepresenter.h"
 
 // VTABLE 0x100d52b0
 // SIZE 0xa0
-class Lego3DWavePresenter : public LegoWavePresenter
+class Lego3DWavePresenter : public MxWavePresenter
 {
 public:
+  // Inlined at 0x1000a217
+  inline Lego3DWavePresenter()
+  {
+    // TODO
+  }
+
   // OFFSET: LEGO1 0x1000d890
   inline virtual const char *ClassName() const override // vtable+0x0c
   {

--- a/LEGO1/legoact2.cpp
+++ b/LEGO1/legoact2.cpp
@@ -1,0 +1,12 @@
+#include "legoact2.h"
+
+#include "decomp.h"
+
+// Uncomment when member class variables are fleshed out.
+// DECOMP_SIZE_ASSERT(LegoAct2, 0x1154); // 0x1000aae9
+
+// OFFSET: LEGO1 0x1004fce0 STUB
+LegoAct2::LegoAct2()
+{
+    // TODO
+}

--- a/LEGO1/legoact2.h
+++ b/LEGO1/legoact2.h
@@ -1,0 +1,14 @@
+#ifndef LEGOACT2_H
+#define LEGOACT2_H
+
+#include "legoworld.h"
+
+// VTABLE 0x100d82e0
+// SIZE 0x1154
+class LegoAct2 : public LegoWorld
+{
+public:
+  LegoAct2();
+};
+
+#endif // LEGOACT2_H

--- a/LEGO1/legoracecar.cpp
+++ b/LEGO1/legoracecar.cpp
@@ -1,0 +1,1 @@
+#include "legoracecar.h"

--- a/LEGO1/legoracecar.h
+++ b/LEGO1/legoracecar.h
@@ -1,0 +1,24 @@
+#ifndef LEGORACECAR_H
+#define LEGORACECAR_H
+
+#include "legocarraceactor.h"
+
+// VTABLE 0x100d58b8
+class LegoRaceCar : public LegoCarRaceActor
+{
+public:
+  // OFFSET: LEGO1 0x10014290
+  inline virtual const char *ClassName() const override // vtable+0x0c
+  {
+    // 0x100f0548
+    return "LegoRaceCar";
+  }
+
+  // OFFSET: LEGO1 0x100142b0
+  inline virtual MxBool IsA(const char *name) const override // vtable+0x10
+  {
+    return !strcmp(name, LegoRaceCar::ClassName()) || LegoCarRaceActor::IsA(name);
+  }
+};
+
+#endif // LEGORACECAR_H


### PR DESCRIPTION
In order to implement the full list of ~100 classes [used in the LegoObjectFactory](https://gist.github.com/Andoryuuta/04904cefe28f29e6c11847a6d54fffd3#file-old_legoobjectfactory-cpp-L3-L21), we need the following classes to exist in the codebase (with each ultimately inheriting from MxCore):

- [x] class LegoMeterPresenter {};
- [x] class Lego3DWavePresenter {};
- [x] class LegoRaceCar {};
- [x] class LegoAct2 {};
- [x] class LegoRaceCarBuildState {}; (LegoVehicleBuildState)
- [x] class LegoCopterBuildState {}; (LegoVehicleBuildState)
- [x] class LegoDuneCarBuildState {}; (LegoVehicleBuildState)
- [x] class LegoJetskiBuildState {}; (LegoVehicleBuildState)
- [x] class Act2State {};
- [ ] class Act2Actor {};
- [ ] class Act2GenActor {};
- [ ] class Motocycle {};
- [ ] class Act3Cop {};
- [ ] class Act3Brickster {};
- [ ] class PizzeriaState {};
- [ ] class CaveEntity {};
- [ ] class JailEntity {};
- [ ] class RaceSkel {};